### PR TITLE
feat:auth

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,18 @@
 import Router from './router/Router';
 import GlobalStyle from './styles/GlobalStyle';
-import {ReactQueryDevtools} from '@tanstack/react-query-devtools';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+ import {
+   useQuery,
+   useMutation,
+   useQueryClient,
+   QueryClient,
+   QueryClientProvider,
+ } from 'react-query';
 // import { ThemeProvider } from 'styled-components';
 // import { isDarkAtom } from './atom';
 // import { useRecoilValue } from 'recoil';
 // import { darkTheme, lightTheme } from './theme';
-
+ const queryClient = new QueryClient();
 const App = () => {
   /**Recoil적용을 위해 임시적으로 다크모드 생성 후 주석 처리 합니다
    * 삭제는 말아주세요
@@ -15,9 +22,11 @@ const App = () => {
   return (
     <>
       {/* <ThemeProvider theme={isDark ? darkTheme : lightTheme}> */}
-      <GlobalStyle />
-      <Router />
-      <ReactQueryDevtools initialIsOpen={true} />
+      <QueryClientProvider client={queryClient}>
+        <GlobalStyle />
+        <Router />
+        {/* <ReactQueryDevtools initialIsOpen={true} /> */}
+      </QueryClientProvider>
       {/* </ThemeProvider> */}
     </>
   );

--- a/src/atom.ts
+++ b/src/atom.ts
@@ -41,13 +41,6 @@ export const toDoState = atom<IToDo[]>({
   default: [],
 });
 
-export const userState = atom<userType>({
-  key: 'userInfo',
-  default: {
-    userId: '',
-    profileImg: 'https://ifh.cc/v-BH3aJj',
-  },
-});
 
 /**todo의 모든 데이터는 get됩니다
  * 카테고리 별 데이터를 get됩니다

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -11,7 +11,6 @@ const Home = () => {
       })
       .catch((error) => {
         console.log( '로그아웃error: ' ,error);
-        
       });
   }
   return (

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -13,6 +13,8 @@ const Home = () => {
         console.log( '로그아웃error: ' ,error);
       });
   }
+  console.log( 'auth.curr: ' ,auth.currentUser);
+  
   return (
     <div>
       Home <button onClick={logOut}>로그아웃</button>

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -38,7 +38,6 @@ const SignIn = () => {
   });
 
   const idList = data?.map((user: userType) => user.id);
-  console.log('idList: ', idList);
 
   const [isViewPW, setIsViewPW] = useState(false);
   const handleClickViewPW = () => {

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -63,13 +63,10 @@ const SignIn = () => {
     } else {
       await signInWithEmailAndPassword(auth, email, pw)
         .then((userCredential) => {
-          console.log('로그인 성공');
           navigate('/home');
         })
         .catch((error) => {
-          const errorMessage = error.message;
-          console.log( 'errorMessage: ' ,errorMessage);
-          
+          const errorMessage = error.message;          
           if (errorMessage.includes('user-not-found')) {
             setErr('가입된 회원이 아닙니다.');
             return;
@@ -89,12 +86,10 @@ const SignIn = () => {
     await signInWithPopup(auth, googleProvider)
       .then((result) => {
         const user = result.user;
-        console.log('user: ', user);
         navigate('/home');
       })
       .catch((error) => {
         const errorMessage = error.message;
-        console.log('error: ', errorMessage);
         return;
       });
   };
@@ -103,12 +98,10 @@ const SignIn = () => {
     await signInWithPopup(auth, githubProvider)
       .then((result) => {
         const user = result.user;
-        console.log('user: ', user);
         navigate('/home');
       })
       .catch((error) => {
         const errorMessage = error.message;
-        console.log('error: ', errorMessage);
       });
   };
 

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -1,25 +1,44 @@
-import { useCallback, useState } from 'react';
+import {useCallback, useState} from 'react';
 import styled from 'styled-components';
-import { AiFillCloseCircle, AiFillEye, AiFillGithub } from 'react-icons/ai';
-import { FcGoogle } from 'react-icons/fc';
-import { useNavigate } from 'react-router';
+import {AiFillCloseCircle, AiFillEye, AiFillGithub} from 'react-icons/ai';
+import {FcGoogle} from 'react-icons/fc';
+import {useNavigate} from 'react-router';
 import {
   GithubAuthProvider,
   GoogleAuthProvider,
   signInWithEmailAndPassword,
   signInWithPopup,
 } from 'firebase/auth';
-import { auth } from '../firebase/Firebase';
-import { ISignUpForm } from '../types';
-import { SubmitHandler, useForm } from 'react-hook-form';
-import { yupResolver } from '@hookform/resolvers/yup';
+import {auth} from '../firebase/Firebase';
+import {ISignUpForm, userType} from '../types';
+import {SubmitHandler, useForm} from 'react-hook-form';
+import {yupResolver} from '@hookform/resolvers/yup';
 import * as yup from 'yup';
-import { CustomModal } from '../components/modal/CustomModal';
+import {CustomModal} from '../components/modal/CustomModal';
 import FindPW from '../components/auth/FindPW';
+import {useMutation, useQuery} from 'react-query';
+import axios, {AxiosResponse} from 'axios';
 
 const SignIn = () => {
   const navigate = useNavigate();
   const [err, setErr] = useState('');
+  const [checkID, setCheckID] = useState(false);
+  const mutation = useMutation((newUser: userType) => {
+    return axios
+      .post('http://localhost:4000/users', newUser)
+      .then((response: AxiosResponse) => {
+        return response;
+      });
+  });
+
+  // uid 중복검사
+  const {data} = useQuery('users', async () => {
+    const response = await axios.get('http://localhost:4000/users');
+    return response.data;
+  });
+
+  const idList = data?.map((user: userType) => user.id);
+  console.log('idList: ', idList);
 
   const [isViewPW, setIsViewPW] = useState(false);
   const handleClickViewPW = () => {
@@ -36,7 +55,7 @@ const SignIn = () => {
   const {
     register,
     handleSubmit,
-    formState: { errors },
+    formState: {errors},
   } = useForm<ISignUpForm>({
     resolver: yupResolver(schema),
   });
@@ -66,7 +85,7 @@ const SignIn = () => {
           navigate('/home');
         })
         .catch((error) => {
-          const errorMessage = error.message;          
+          const errorMessage = error.message;
           if (errorMessage.includes('user-not-found')) {
             setErr('가입된 회원이 아닙니다.');
             return;
@@ -77,7 +96,6 @@ const SignIn = () => {
     }
   };
 
-
   // 구글, 깃허브 로그인
   const googleProvider = new GoogleAuthProvider();
   const githubProvider = new GithubAuthProvider();
@@ -86,11 +104,38 @@ const SignIn = () => {
     await signInWithPopup(auth, googleProvider)
       .then((result) => {
         const user = result.user;
+        const uid = auth.currentUser?.uid;
+        const isId = idList.includes(auth.currentUser?.uid);
+        if (!isId) {
+          mutation.mutate({
+            id: uid,
+            email,
+            password: pw,
+            phoneNumber: '',
+            area: '',
+            nickName: auth.currentUser?.displayName,
+            photoURL: auth.currentUser?.photoURL,
+            score: 0,
+            follower: [],
+            follow: [],
+            point: 0,
+            matchingItem: [],
+            comment: [],
+          });
+          console.log('데이터 추가: ');
+        } else {
+          console.log('데이터 추가XX: ');
+        }
         navigate('/home');
       })
       .catch((error) => {
         const errorMessage = error.message;
-        return;
+        if (
+          errorMessage.includes('auth/account-exists-with-different-credential')
+        ) {
+          setErr('이미 가입된 회원입니다.');
+          return;
+        }
       });
   };
 
@@ -98,10 +143,38 @@ const SignIn = () => {
     await signInWithPopup(auth, githubProvider)
       .then((result) => {
         const user = result.user;
+        const uid = auth.currentUser?.uid;
+        const isId = idList.includes(auth.currentUser?.uid);
+        if (!isId) {
+          mutation.mutate({
+            id: uid,
+            email,
+            password: pw,
+            phoneNumber: '',
+            area: '',
+            nickName: auth.currentUser?.displayName,
+            photoURL: auth.currentUser?.photoURL,
+            score: 0,
+            follower: [],
+            follow: [],
+            point: 0,
+            matchingItem: [],
+            comment: [],
+          });
+          console.log('데이터 추가: ');
+        } else {
+          console.log('데이터 추가XX: ');
+        }
         navigate('/home');
       })
       .catch((error) => {
         const errorMessage = error.message;
+        if (
+          errorMessage.includes('auth/account-exists-with-different-credential')
+        ) {
+          setErr('이미 가입된 회원입니다.');
+          return;
+        }
       });
   };
 
@@ -121,10 +194,10 @@ const SignIn = () => {
           <InputContainer>
             <ItemContainer>
               <InputBox
-                type="email"
-                placeholder="이메일"
+                type='email'
+                placeholder='이메일'
                 {...register('email')}
-                style={{ borderColor: errors?.email?.message ? 'red' : '' }}
+                style={{borderColor: errors?.email?.message ? 'red' : ''}}
                 onChange={onChangeEmailHandler}
                 value={email}
               />
@@ -141,16 +214,16 @@ const SignIn = () => {
             <ItemContainer>
               <InputBox
                 type={isViewPW ? 'text' : 'password'}
-                placeholder="비밀번호"
+                placeholder='비밀번호'
                 {...register('pw')}
-                style={{ borderColor: errors?.pw?.message ? 'red' : '' }}
+                style={{borderColor: errors?.pw?.message ? 'red' : ''}}
                 onChange={onChangePwHandler}
                 value={pw}
               />
               {pw ? (
                 <ViewIcon
                   onClick={handleClickViewPW}
-                  style={{ color: isViewPW ? 'black' : '#ddd' }}
+                  style={{color: isViewPW ? 'black' : '#ddd'}}
                 />
               ) : undefined}
               {errors.pw && errors.pw.type === 'required' && (
@@ -183,8 +256,8 @@ const SignIn = () => {
           <CustomModal
             modal={isModalActive}
             setModal={setIsModalActive}
-            width="600"
-            height="300"
+            width='600'
+            height='300'
             element={
               <ComponentSpace>
                 <FindPW />

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -168,76 +168,6 @@ const SignUp = () => {
     }
   };
 
-  // 구글, 깃허브 로그인
-  const googleProvider = new GoogleAuthProvider();
-  const githubProvider = new GithubAuthProvider();
-
-  const onGoogleClick = async () => {
-    await signInWithPopup(auth, googleProvider)
-      .then((result) => {
-        const user = result.user;
-        const uid = auth.currentUser?.uid;
-        mutation.mutate({
-          id: uid,
-          email,
-          password: pw,
-          phoneNumber: '',
-          area: '',
-          nickName: auth.currentUser?.displayName,
-          photoURL: auth.currentUser?.photoURL,
-          score: 0,
-          follower: [],
-          follow: [],
-          point: 0,
-          matchingItem: [],
-          comment: [],
-        });
-        navigate('/home');
-      })
-      .catch((error) => {
-        const errorMessage = error.message;
-        if (
-          errorMessage.includes('auth/account-exists-with-different-credential')
-        ) {
-          setErr('이미 가입된 회원입니다.');
-          return;
-        }
-      });
-  };
-
-  const onGithubClick = async () => {
-    await signInWithPopup(auth, githubProvider)
-      .then((result) => {
-        const user = result.user;
-        const uid = auth.currentUser?.uid;
-        mutation.mutate({
-          id: uid,
-          email,
-          password: pw,
-          phoneNumber: '',
-          area: '',
-          nickName: auth.currentUser?.displayName,
-          photoURL: auth.currentUser?.photoURL,
-          score: 0,
-          follower: [],
-          follow: [],
-          point: 0,
-          matchingItem: [],
-          comment: [],
-        });
-        navigate('/home');
-      })
-      .catch((error) => {
-        const errorMessage = error.message;
-        if (
-          errorMessage.includes('auth/account-exists-with-different-credential')
-        ) {
-          setErr('이미 가입된 회원입니다.');
-          return;
-        }
-      });
-  };
-
   return (
     <>
       <Container>
@@ -333,11 +263,6 @@ const SignUp = () => {
 
           <JoinButton>등록하기</JoinButton>
         </FormTag>
-        <PTag>SNS 회원가입</PTag>
-        <SocialLoginButtonContainer>
-          <GoogleIcon onClick={onGoogleClick} />
-          <GitIcon onClick={onGithubClick} />
-        </SocialLoginButtonContainer>
         <MoveSignInButton onClick={() => navigate('/signin')}>
           이미 회원이신가요?
         </MoveSignInButton>

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -1,10 +1,10 @@
-import {useState} from 'react';
+import {useEffect, useState} from 'react';
 import styled from 'styled-components';
 import {AiFillCloseCircle, AiFillEye, AiFillGithub} from 'react-icons/ai';
 import {FcGoogle} from 'react-icons/fc';
 import {useNavigate} from 'react-router';
 import {useForm, SubmitHandler} from 'react-hook-form';
-import {ISignUpForm} from '../types';
+import {ISignUpForm, userType} from '../types';
 import * as yup from 'yup';
 import {yupResolver} from '@hookform/resolvers/yup';
 import {
@@ -14,20 +14,21 @@ import {
   signInWithPopup,
 } from 'firebase/auth';
 import {auth} from '../firebase/Firebase';
+import {useMutation, useQuery, useQueryClient} from 'react-query';
+import axios, {AxiosResponse} from 'axios';
 
 const SignUp = () => {
   const navigate = useNavigate();
   const [err, setErr] = useState('');
-  // 비밀번호 눈알 아이콘 클릭 시 type 변경 할 수 있는 함수
-  // 비밀번호 , 비밀번호체크랑 따로 구현했습니다.
   const [isViewPW, setIsViewPW] = useState(false);
   const [isViewCheckPW, setIsViewCheckPW] = useState(false);
-  const handleClickViewPW = () => {
-    setIsViewPW(!isViewPW);
-  };
-  const handleClickCheckPW = () => {
-    setIsViewCheckPW(!isViewCheckPW);
-  };
+  const [pw, setPw] = useState('');
+  const [checkPw, setCheckPw] = useState('');
+  const [nickName, setNickName] = useState('');
+  const [email, setEmail] = useState('');
+  const [checkNick, setCheckNick] = useState(0);
+  const [errMsg, setErrMsg] = useState('');
+  // 닉네임 중복 로직 : 중복확인 버튼 안누르면 0, 눌렀는데 중복이면 1, 눌렀는데 중복 없으면 2 (2가 되야 통과임)
 
   // 유효성 검사를 위한 코드들
   // 영문+숫자+특수기호 포함 8~20자 비밀번호 정규식
@@ -51,51 +52,119 @@ const SignUp = () => {
     resolver: yupResolver(schema),
   });
 
+  // 회원가입 성공 시 users에 data 추가
+  const mutation = useMutation((newUser: userType) => {
+    return axios
+      .post('http://localhost:4000/users', newUser)
+      .then((response: AxiosResponse) => {
+        return response;
+      });
+  });
+
+  // 닉네임 중복검사
+  const {data} = useQuery('users', async () => {
+    const response = await axios.get('http://localhost:4000/users');
+    return response.data;
+  });
+
+  const nickNameList = data?.map((user: userType) => user.nickName);
+
+  // 비밀번호 눈알 아이콘 클릭 시 type 변경 할 수 있는 함수
+  // 비밀번호 , 비밀번호체크랑 따로 구현했습니다.
+  const handleClickViewPW = () => {
+    setIsViewPW(!isViewPW);
+  };
+  const handleClickCheckPW = () => {
+    setIsViewCheckPW(!isViewCheckPW);
+  };
+
+  // x 버튼 누르면 email input 초기화
+  const handleInputValueClickBT = () => {
+    setEmail('');
+  };
   // input state 관리해주는 함수들
-  const [email, setEmail] = useState('');
   const onChangeEmailHandler = (
     e: React.ChangeEvent<HTMLInputElement>
   ): void => {
     setEmail(e.target.value);
   };
-  // x 버튼 누르면 email input 초기화
-  const handleInputValueClickBT = () => {
-    setEmail('');
-  };
 
-  const [pw, setPw] = useState('');
   const onChangePwHandler = (e: React.ChangeEvent<HTMLInputElement>): void => {
     setPw(e.target.value);
   };
 
-  const [checkPw, setCheckPw] = useState('');
   const onChangecheckPwHandler = (
     e: React.ChangeEvent<HTMLInputElement>
   ): void => {
     setCheckPw(e.target.value);
   };
 
+  const onChangeNickNameHandler = (
+    e: React.ChangeEvent<HTMLInputElement>
+  ): void => {
+    setNickName(e.target.value);
+  };
+
+  // 닉네임 중복확인 버튼 누르면 실행되는 함수
+  const handleCheckOverlapNickName = () => {
+    if (!nickName) {
+      setErrMsg('닉네임을 입력해주세요.');
+    }
+    const result = nickNameList.includes(nickName);
+    if (result) {
+      setCheckNick(1);
+    } else {
+      if (nickName) {
+        setCheckNick(2);
+        setErrMsg('✅중복되는 닉네임이 없습니다.');
+      }
+    }
+  };
+
+  // 등록하기 버튼 누르면 실행되는 함수
   const onSubmitHandler: SubmitHandler<ISignUpForm> = async () => {
     if (errors.checkPw || errors.email || errors.pw) {
       return;
     } else {
-      await createUserWithEmailAndPassword(auth, email, pw)
-        .then((userCredential) => {
-          console.log('회원가입 성공');
+      if (checkNick === 0) {
+        setErrMsg('닉네임 중복을 확인해주세요.');
+        return;
+      } else if (checkNick === 1) {
+        return;
+      } else {
+        await createUserWithEmailAndPassword(auth, email, pw)
+          .then((userCredential) => {
+            setEmail('');
+            setPw('');
+            setCheckPw('');
+            setErr('');
+            setNickName('');
+            mutation.mutate({
+              id: auth.currentUser?.uid,
+              email,
+              password: pw,
+              phoneNumber: '',
+              area: '',
+              nickName,
+              photoURL: auth.currentUser?.photoURL,
+              score: 0,
+              follower: [],
+              follow: [],
+              point: 0,
+              matchingItem: [],
+              comment: [],
+            });
+            navigate('/home');
+          })
+          .catch((error) => {
+            const errorMessage = error.message;
 
-          setEmail('');
-          setPw('');
-          setCheckPw('');
-          setErr('');
-        })
-        .catch((error) => {
-          const errorMessage = error.message;
-
-          if (errorMessage.includes('auth/email-already-in-use')) {
-            setErr('이미 가입된 회원입니다.');
-            return;
-          }
-        });
+            if (errorMessage.includes('auth/email-already-in-use')) {
+              setErr('이미 가입된 회원입니다.');
+              return;
+            }
+          });
+      }
     }
   };
 
@@ -107,12 +176,26 @@ const SignUp = () => {
     await signInWithPopup(auth, googleProvider)
       .then((result) => {
         const user = result.user;
-        console.log('user: ', user);
+        const uid = auth.currentUser?.uid;
+        mutation.mutate({
+          id: uid,
+          email,
+          password: pw,
+          phoneNumber: '',
+          area: '',
+          nickName: auth.currentUser?.displayName,
+          photoURL: auth.currentUser?.photoURL,
+          score: 0,
+          follower: [],
+          follow: [],
+          point: 0,
+          matchingItem: [],
+          comment: [],
+        });
         navigate('/home');
       })
       .catch((error) => {
         const errorMessage = error.message;
-        console.log('error: ', errorMessage);
         if (
           errorMessage.includes('auth/account-exists-with-different-credential')
         ) {
@@ -126,12 +209,26 @@ const SignUp = () => {
     await signInWithPopup(auth, githubProvider)
       .then((result) => {
         const user = result.user;
-        console.log('user: ', user);
+        const uid = auth.currentUser?.uid;
+        mutation.mutate({
+          id: uid,
+          email,
+          password: pw,
+          phoneNumber: '',
+          area: '',
+          nickName: auth.currentUser?.displayName,
+          photoURL: auth.currentUser?.photoURL,
+          score: 0,
+          follower: [],
+          follow: [],
+          point: 0,
+          matchingItem: [],
+          comment: [],
+        });
         navigate('/home');
       })
       .catch((error) => {
         const errorMessage = error.message;
-        console.log('error: ', errorMessage);
         if (
           errorMessage.includes('auth/account-exists-with-different-credential')
         ) {
@@ -218,6 +315,22 @@ const SignUp = () => {
               {err && <ErrorMSG>{err}</ErrorMSG>}
             </ItemContainer>
           </InputContainer>
+          <ItemContainer>
+            <InputBox
+              type='text'
+              placeholder='닉네임'
+              style={{borderColor: errors?.pw?.message ? 'red' : ''}}
+              onChange={onChangeNickNameHandler}
+              value={nickName}
+            />
+            <CheckBT type='button' onClick={handleCheckOverlapNickName}>
+              중복확인
+            </CheckBT>
+            {checkNick === 1 && <ErrorMSG>중복된 닉네임입니다.</ErrorMSG>}
+            {checkNick === 0 && <ErrorMSG>{errMsg}</ErrorMSG>}
+            {checkNick === 2 && <PassMSG>{errMsg}</PassMSG>}
+          </ItemContainer>
+
           <JoinButton>등록하기</JoinButton>
         </FormTag>
         <PTag>SNS 회원가입</PTag>
@@ -235,6 +348,26 @@ const SignUp = () => {
 
 export default SignUp;
 
+const CheckBT = styled.button`
+  width: 20%;
+  height: 30px;
+  border: none;
+  border-radius: 6px;
+  color: white;
+  font-size: 0.9rem;
+  background-color: #e4e4e4;
+  position: absolute;
+  bottom: 25px;
+  right: 5px;
+  cursor: pointer;
+  &:hover {
+    background-color: #e1e1e1;
+  }
+`;
+const PassMSG = styled.p`
+  color: green;
+  font-size: 0.8rem;
+`;
 const ErrorMSG = styled.p`
   color: red;
   font-size: 0.8rem;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -5,8 +5,28 @@ export interface ISignUpForm {
 }
 
 export interface userType {
-  userId: string;
-  profileImg: string;
+  id: string | undefined;
+  email: string;
+  password: string;
+  phoneNumber: string; //전화번호
+  area: string; //지역(select option으로 ㅇㅇ시 / ㅇㅇ구 / ㅇㅇ동)
+  nickName: string | null | undefined;
+  photoURL: string | null | undefined;
+  score: number; //평점
+  follower: Array; // 나를 좋아요 누른 유저 uid <- length로만 나타냄
+  follow: Array; // 내가 좋아요 한 유저 uid
+  point: number;
+  matchingItem: Array[{
+    id: string; //매칭된 서비스의 문서id
+    isMatching: boolean; // todos의 isMatching이랑 둘다 true여야 isResolve가 true로 변하고, isResolve가 true이면 완료,취소버튼 안보이고 완료 라는 문구가 글에 나오게끔 해야함
+    isResolve: boolean; // 매칭된 문제가 해결됐는지
+  }];
+  comment: Array[{
+    id: string;
+    writer: string; // 댓글 작성자 uid
+    content: string; //댓글내용
+    date: string; //댓글 단 시간
+  }];
 }
 
 /**삭제하지 말아주세요 */

--- a/users.json
+++ b/users.json
@@ -1,0 +1,49 @@
+{
+  "users": [
+    {
+      "id": "60PTDKT4geemeQuMx66y2kwUSpQ2",
+      "email": "",
+      "password": "",
+      "phoneNumber": "",
+      "area": "",
+      "nickName": "김미영",
+      "photoURL": "https://lh3.googleusercontent.com/a/AEdFTp4o7DZ8rGAD3pbny4PnXhADq0p10ONHWJ9DiPWL=s96-c",
+      "score": 0,
+      "follower": [],
+      "follow": [],
+      "point": 0,
+      "matchingItem": [],
+      "comment": []
+    },
+    {
+      "id": "UbWQ8uVfBkVT0KLfEcLrOztKPIu2",
+      "email": "",
+      "password": "",
+      "phoneNumber": "",
+      "area": "",
+      "nickName": "Miyoung@Kim",
+      "photoURL": "https://avatars.githubusercontent.com/u/110464690?v=4",
+      "score": 0,
+      "follower": [],
+      "follow": [],
+      "point": 0,
+      "matchingItem": [],
+      "comment": []
+    },
+    {
+      "id": "aYU25F5tE5a1hrAZIa0htFNm7RM2",
+      "email": "aldud7798555@gmail.com",
+      "password": "82rydryd!",
+      "phoneNumber": "",
+      "area": "",
+      "nickName": "도라에몽",
+      "photoURL": null,
+      "score": 0,
+      "follower": [],
+      "follow": [],
+      "point": 0,
+      "matchingItem": [],
+      "comment": []
+    }
+  ]
+}

--- a/users.json
+++ b/users.json
@@ -44,6 +44,51 @@
       "point": 0,
       "matchingItem": [],
       "comment": []
+    },
+    {
+      "id": "y9b886SJsfQhHOkbT2ewWHBYET53",
+      "email": "",
+      "password": "",
+      "phoneNumber": "",
+      "area": "",
+      "nickName": "김미영1",
+      "photoURL": "https://lh3.googleusercontent.com/a/AEdFTp4o7DZ8rGAD3pbny4PnXhADq0p10ONHWJ9DiPWL=s96-c",
+      "score": 0,
+      "follower": [],
+      "follow": [],
+      "point": 0,
+      "matchingItem": [],
+      "comment": []
+    },
+    {
+      "id": "5foIZi5kzBXXDQxm4kHnSN7aSJK2",
+      "email": "",
+      "password": "",
+      "phoneNumber": "",
+      "area": "",
+      "nickName": "김미영",
+      "photoURL": "https://lh3.googleusercontent.com/a/AEdFTp4o7DZ8rGAD3pbny4PnXhADq0p10ONHWJ9DiPWL=s96-c",
+      "score": 0,
+      "follower": [],
+      "follow": [],
+      "point": 0,
+      "matchingItem": [],
+      "comment": []
+    },
+    {
+      "id": "E5Mx0yJINSQhpFhm9ZRr5nL3PDw2",
+      "email": "",
+      "password": "",
+      "phoneNumber": "",
+      "area": "",
+      "nickName": "Miyoung@Kim",
+      "photoURL": "https://avatars.githubusercontent.com/u/110464690?v=4",
+      "score": 0,
+      "follower": [],
+      "follow": [],
+      "point": 0,
+      "matchingItem": [],
+      "comment": []
     }
   ]
 }


### PR DESCRIPTION
- react query 이용하여 회원가입 시 닉네임 중복검사 로직 추가
- react query 이용하여 회원가입 성공 시 user 정보 data에 저장

## What is this PR? 🔍

- 회원가입 시 닉네임 중복검사가 가능해집니다.
- 회원가입 성공 시 user 정보가 users.json에 저장됩니다.
- 소셜 로그인은 로그인페이지에서만 가능하게 변경되었습니다.
- 소셜 로그인 시 동일한 uid가 없어야만 유저 정보가 저장 됩니다.
## branch

- feat/auth -> dev

## Changes 📝

- react query 이용하여 회원가입 시 닉네임 중복검사 로직 추가
- react query 이용하여 회원가입 성공 시 user 정보 data에 저장
- 회원가입 페이지 소셜로그인 삭제
- 로그인 페이지에서 소셜 로그인 시 동일한 uid가 data에 존재하지 않아야만 user data 저장되게 했습니다.


by @km-young 
