### PR TITLE
feat(Mypage): 마이페이지에서 구, 판매자 닉네임을 보여줍니다.

### DIFF
--- a/src/components/mypage/PointHistoryList.tsx
+++ b/src/components/mypage/PointHistoryList.tsx
@@ -77,18 +77,18 @@ const PointHistoryList = () => {
             전체
           </PointWrapper>
           <PointWrapper
-            onClick={() => setCategory('출금')}
-            style={category === '출금' ? categoryStyle : undefined}
-            aria-label="출금"
-          >
-            출금
-          </PointWrapper>
-          <PointWrapper
             onClick={() => setCategory('입금')}
             style={category === '입금' ? categoryStyle : undefined}
             aria-label="입금"
           >
             입금
+          </PointWrapper>
+          <PointWrapper
+            onClick={() => setCategory('출금')}
+            style={category === '출금' ? categoryStyle : undefined}
+            aria-label="출금"
+          >
+            출금
           </PointWrapper>
         </DropDownBox>
       </DropDown>

--- a/src/components/mypage/PointModal.tsx
+++ b/src/components/mypage/PointModal.tsx
@@ -13,6 +13,7 @@ const PointModal = () => {
 
   // 로그인한 유저 정보를 불러옵니다
   const { data: profileData } = useQuery(['users'], () => getUsers(saveUser));
+  console.log('profileData', profileData);
 
   const pointChargeHandle = () => {
     customInfoAlert('이벤트 기간 동안 지급된 포인트로 활동하세요!');

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -209,6 +209,7 @@ const Detail = () => {
             id: uuid,
             postsId: id,
             buyerUid: saveUser.uid,
+            buyerNickName: user?.nickName,
             sellerUid: post?.[0]?.sellerUid,
             sellerNickName: post?.[0]?.nickName,
             title: post?.[0]?.title,

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import {
   getOnSalePostBuyer,
@@ -85,7 +85,10 @@ const MyPage = () => {
     return post.isDone === false;
   });
 
-  /**회원탈퇴 */
+  /*판매대기
+   */
+
+  /*회원탈퇴 */
   const user = auth.currentUser;
 
   const deleteAuth = () => {
@@ -265,6 +268,7 @@ const MyPage = () => {
                             .replace(/\B(?=(\d{3})+(?!\d))/g, ',')}
                           P
                         </a.MyLikeDiv>
+                        <p>{list.buyerNickName}</p>
                       </a.MyLikeList>
                     );
                   })
@@ -285,6 +289,7 @@ const MyPage = () => {
                             .replace(/\B(?=(\d{3})+(?!\d))/g, ',')}
                           P
                         </a.MyLikeDiv>
+                        <p>{list.buyerNickName}</p>
                       </a.MyLikeList>
                     );
                   })

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -74,6 +74,7 @@ export interface onSalePostType {
   id: string | undefined;
   postsId: string | undefined;
   buyerUid: string | null | undefined;
+  buyerNickName: string | null | undefined;
   sellerUid: string | null | undefined;
   sellerNickName: string | null | undefined;
   title: string;


### PR DESCRIPTION
by kimnamgyu93

## What is this PR? 🔍

- 마이페이지의 거래내역에 해당 포스트의 구매자, 판매자의 닉네임을 나타냅니다.
- 입금과 출금의 텍스트가 반대로 나타나는 현상을 수정합니다.

## branch

- feat/mypage -> dev

## Changes 📝

- onSalePosts에 buyerNickName을 추가합니다.
- 마이페이지에서 구매자 닉네임도  표시합니다.
- PointHistory에서 입금과 출금의 텍스트 위치를 반대로 작성합니다.

#141 
 by @Kimnamgyu93 
